### PR TITLE
Error when recursively search down directory tree

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,9 @@ BroccoliSpritesmith.prototype.write = function (readTree, destDir) {
     return null;
   }
 
-  var spritesImages = walkSync(spriteImagePath).map(function(file){
+  var spritesImages = walkSync(spriteImagePath).filter(function(path) {
+    return path.lastIndexOf(ext) === path.length - ext.length;
+  }).map(function(file){
     self.log("\tdetecting:", file);
     return path.join(spriteImagePath, file);
   });


### PR DESCRIPTION
This PR fixes that by filtering the sprite images by only the valid extensions.
