### PR TITLE
Fix default options for scss and image generators

### DIFF
--- a/generators/image.js
+++ b/generators/image.js
@@ -13,11 +13,11 @@ function ImageGenerator (options) {
 		options = {}
 	}
 
-	options = assign({}, options, {
+	options = assign({}, {
 		outputPath: 'assets', 
 		name: 'sprites',
 		ext: '.png'
-	})
+	}, options)
 
 	if (!options.destDir) {
 		throw new Error('must have destDir argument in options');

--- a/generators/scss.js
+++ b/generators/scss.js
@@ -15,24 +15,21 @@ function SCSSGenerator (options) {
 
 	this.log('options', options);
 
-	options = assign({}, options, {
+	this.options = assign({}, {
 		outputPath: 'app/styles', 
-        spritesPath: 'assets',
 		name: 'sprites',
 		ext: '.scss'
-	})
-
+	}, options)
 
 	if (!options.destDir) {
 		throw new Error('must have destDir argument in options');
 	}
 
-	this.relativePath = options.outputPath;
-    this.spritesPath = options.spritesPath;
-	this.outputPath = path.join(options.destDir, options.outputPath);
-	this.outputFile = path.join(this.outputPath, options.name + options.ext);
-	this.ext = options.ext;
-	this.spriteName = options.name;
+	this.relativePath = this.options.outputPath;
+	this.outputPath = path.join(options.destDir, this.options.outputPath);
+	this.outputFile = path.join(this.outputPath, this.options.name + this.options.ext);
+	this.ext = this.options.ext;
+	this.spriteName = this.options.name;
 }
 
 util.inherits(SCSSGenerator, Base);
@@ -64,7 +61,7 @@ SCSSGenerator.prototype.generateSCSSFile = function(config) {
     rule['offsetY'] = rule.y > 0 ? -rule.y : 0;
     rule['totalWidth'] = config.properties.width;
     rule['totalHeight'] = config.properties.height;
-    rule['imagePath'] = path.join('../', this.spritesPath, this.spriteName + '.png');
+    rule['imagePath'] = path.join('../', this.options.outputPath, this.spriteName + '.png');
 
     context += this.generateSCSS(rule);
   }
@@ -102,7 +99,6 @@ SCSSGenerator.prototype.generateSCSSFile = function(config) {
 
 SCSSGenerator.prototype.generate = function(data){
 	mkdirp.sync(this.outputPath);
-
     fs.writeFileSync(this.outputFile, this.generateSCSSFile(data));
 	this.log("\twrite to", this.outputFile);
 }

--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ BroccoliSpritesmith.prototype.write = function (readTree, destDir) {
   var self = this;
   var ext = this.options.ext || '.png';
   var outputPath = this.options.outputPath;
+  var spriteName = this.options.spriteName;
   var spriteImagePath = path.join(process.cwd(), this.inputTree);
 
 
@@ -75,8 +76,8 @@ BroccoliSpritesmith.prototype.write = function (readTree, destDir) {
 
         var generators = self.loadGenerators({
           destDir: destDir,
-          outputPath: outputPath, 
-
+          outputPath: outputPath,
+          name: spriteName
         });
 
         self.log('load', generators.length, 'generator success!');
@@ -111,7 +112,6 @@ BroccoliSpritesmith.prototype.loadGenerators = function(options) {
   }
 
   this.log('loadGenerators...', outputs);
-
   return outputs.map(function(type){
     return  self.loadGenerator(type, options);
   }).filter(function(generator){


### PR DESCRIPTION
Arguments for assign() function was in a wrong order.
Sprite name option in scss-generator was hardcoded to 'sprites', I added
new option 'spriteName' for it.
