### PR TITLE
Engine option now passed to spritesmith

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Example `options` object:
     ext: 'png',
 
     // sprite engine arguments   
-    engine: 'auto',
+    engine: 'auto', // e.g. phantomjs, canvas, ...
     algorithm: 'binary-tree',
     padding: 5
 }
@@ -38,7 +38,7 @@ Example `options` object:
 
 `output` defaults is 'all', can be set `'scss'`, `'image'`, '`less`', but now only support `'scss'` , `'image'`
 
-`engine`, `algorithm`, `padding` is spritesmit [options](https://github.com/Ensighten/spritesmith#documentation)
+`engine`, `algorithm`, `padding` are spritesmith [options](https://github.com/Ensighten/spritesmith#documentation)
 
 License
 

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function BroccoliSpritesmith (inputTree, options) {
     spriteName: 'sprites',
     ext: 'png',
 
-    // sprite engine arguments   
+    // sprite engine arguments
     engine: 'auto',
     algorithm: 'binary-tree',
     padding: 5
@@ -64,7 +64,8 @@ BroccoliSpritesmith.prototype.write = function (readTree, destDir) {
   var runOptions = {
     src: spritesImages,
     padding: this.options.padding,
-    algorithm: this.options.algorithm    
+    algorithm: this.options.algorithm,
+    engine: this.options.engine
   };
 
   return new Promise(function(resolve, reject){
@@ -75,7 +76,7 @@ BroccoliSpritesmith.prototype.write = function (readTree, destDir) {
 
         var generators = self.loadGenerators({
           destDir: destDir,
-          outputPath: outputPath, 
+          outputPath: outputPath,
 
         });
 
@@ -136,7 +137,7 @@ function compile (template, context) {
   var pos = 0;
   while ((result = patt.exec(template)) != null)  {
     var found = result[1];
-    var lastIndex = patt.lastIndex || 0;    
+    var lastIndex = patt.lastIndex || 0;
     var startIndex = lastIndex - result[0].length
     // console.log(result[0], pos, startIndex, lastIndex);
 


### PR DESCRIPTION
I wanted to try out phantomjssmith and found out that the `engine` option wasn't correctly passed to spritesmith. This should fix the bug.
